### PR TITLE
fix(Storybook): replace hard-coded library name in storybook config

### DIFF
--- a/libs/stencil/src/schematics/storybook/init/files/lib/.storybook/config.ts.template
+++ b/libs/stencil/src/schematics/storybook/init/files/lib/.storybook/config.ts.template
@@ -1,6 +1,6 @@
 import { configure, addDecorator } from '@storybook/html';
 import { withKnobs } from '@storybook/addon-knobs';
-import { defineCustomElements } from '<%= offsetFromRoot %>../dist/libs/library/loader';
+import { defineCustomElements } from '<%= offsetFromRoot %>../dist/libs/<%= projectName %>/loader';
 
 defineCustomElements();
 

--- a/libs/stencil/src/schematics/storybook/init/init.ts
+++ b/libs/stencil/src/schematics/storybook/init/init.ts
@@ -118,6 +118,7 @@ function createLibStorybookDir(projectName: string, js: boolean): Rule {
       applyWithSkipExisting(url('./files/lib'), [
         applyTemplates({
           offsetFromRoot: offsetFromRoot(projectConfig.root),
+          projectName,
         }),
         move(projectConfig.root),
         js ? toJS() : noop(),


### PR DESCRIPTION
Fixes storybook config.ts template referring to a hard-coded library name "library" instead of the provided project name.