### PR TITLE
fix(stencil.config): set explicit directory for library build

### DIFF
--- a/libs/stencil/src/schematics/library/files/lib/stencil.config.ts.template
+++ b/libs/stencil/src/schematics/library/files/lib/stencil.config.ts.template
@@ -19,13 +19,15 @@ export const config: Config = {
   outputTargets: [
     {
       type: 'dist',
-      esmLoaderPath: '../loader'
+      esmLoaderPath: '../loader',
+      dir: '../../dist/libs/<%= projectName %>/dist',
     },
     {
       type: 'docs-readme'
     },
     {
       type: 'www',
+      dir: '../../dist/libs/<%= projectName %>/www',
       serviceWorker: null // disable service workers
     }
   ],


### PR DESCRIPTION
Modify stencil.config to explicitly use the outer dist folder. This consolidates all build artifacts